### PR TITLE
Group by cabecera

### DIFF
--- a/urlshortener-main/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/IndentifyInfoClientUseCase.kt
+++ b/urlshortener-main/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/IndentifyInfoClientUseCase.kt
@@ -8,18 +8,30 @@ import es.unizar.urlshortener.core.*
 /**
  *
  * Given an id representing a Short Url, returns accumulated User-Agent info.
- *
- *
  */
+
 interface IdentifyInfoClientUseCase {
+        /**
+         * Retrieves accumulated User-Agent info for a Short Url.
+         * @param id Short Url hash
+         * @return Map containing User-Agent info grouped by platform and browser with their respective counts
+         */
         fun returnInfoShortUrl(id: String): Map<String, Int>
 }
 
-
+/**
+ * Implementation of IdentifyInfoClientUseCase interface.
+ * @param clickRepository Service to interact with Click data
+ */
 class IdentifyInfoClientUseCaseImpl(
     private val clickRepository: ClickRepositoryService
 ) : IdentifyInfoClientUseCase {
 
+    /**
+     * Retrieves accumulated User-Agent info for a Short Url.
+     * @param id Short Url id
+     * @return Map containing User-Agent info grouped by platform and browser with their respective counts
+     */
     override fun returnInfoShortUrl(id: String): Map<String, Int> {
         val clicks = clickRepository.findByUrlHash(id)
         return clicks

--- a/urlshortener-main/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/IndentifyInfoClientUseCase.kt
+++ b/urlshortener-main/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/IndentifyInfoClientUseCase.kt
@@ -12,23 +12,18 @@ import es.unizar.urlshortener.core.*
  *
  */
 interface IdentifyInfoClientUseCase {
-        fun returnInfoShortUrl(id: String): List<InfoClient>
+        fun returnInfoShortUrl(id: String): Map<String, Int>
 }
 
-data class InfoClient (
-    val ip: String? = null,
-    val browser: String? = null,
-    val platform: String? = null,
-)
 
 class IdentifyInfoClientUseCaseImpl(
     private val clickRepository: ClickRepositoryService
 ) : IdentifyInfoClientUseCase {
 
-    override fun returnInfoShortUrl(id: String): List<InfoClient> {
-       val clicks = clickRepository.findByUrlHash(id)
-        return clicks.map{
-            InfoClient(it.properties.ip, it.properties.browser, it.properties.platform)
-        }
+    override fun returnInfoShortUrl(id: String): Map<String, Int> {
+        val clicks = clickRepository.findByUrlHash(id)
+        return clicks
+            .groupBy { "${it.properties.platform} - ${it.properties.browser}" }
+            .mapValues { (_, value) -> value.size }
     }
 }

--- a/urlshortener-main/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/IsReachableUseCase.kt
+++ b/urlshortener-main/core/src/main/kotlin/es/unizar/urlshortener/core/usecases/IsReachableUseCase.kt
@@ -2,7 +2,6 @@
 
 package es.unizar.urlshortener.core.usecases
 
-import es.unizar.urlshortener.core.*
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -14,12 +13,25 @@ import java.net.URL
  *
  */
 interface IsReachableUseCase {
+    /**
+     * Checks if the provided URL is reachable.
+     * @param url The URL to check for reachability
+     * @return Boolean indicating if the URL is reachable
+     */
     fun isReachable(url: String): Boolean
 }
 
-class IsReachableUseCaseImpl(
-    private val validatorService: ValidatorService
-) : IsReachableUseCase {
+/**
+ * Implementation of IsReachableUseCase interface.
+ */
+class IsReachableUseCaseImpl
+    : IsReachableUseCase {
+
+    /**
+     * Checks if the provided URL is reachable by making a GET request and verifying the response code.
+     * @param url The URL to check for reachability
+     * @return Boolean indicating if the URL is reachable
+     */
     override fun isReachable(url: String): Boolean {
         var attempts = 0
         val maxAttempts = 3

--- a/urlshortener-main/delivery/src/main/kotlin/es/unizar/urlshortener/infrastructure/delivery/UrlShortenerController.kt
+++ b/urlshortener-main/delivery/src/main/kotlin/es/unizar/urlshortener/infrastructure/delivery/UrlShortenerController.kt
@@ -57,6 +57,12 @@ interface UrlShortenerController {
      */
     fun getQR(id: String, request: HttpServletRequest): ResponseEntity<ByteArrayResource>
 
+    /**
+     * Retrieves header information for a given ID from the HTTP request.
+     * @param id The ID representing the hash where the user is redirected
+     * @param request The HttpServletRequest containing the header information
+     * @return ResponseEntity containing the header information of all clicks to a given hash
+     */
     fun returnInfoHeader(id: String, request: HttpServletRequest): ResponseEntity<Any>
 
 }


### PR DESCRIPTION
Funcionalidad de identificar informacion de la cabecera del cliente para cada hash. Faltaría mostrarlo en el fron a modo de dashboard